### PR TITLE
Possible fixes for TAB key not triggering steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,14 @@ Install via [Package Control](https://packagecontrol.io/installation)
 ## How do I use it?
 The tab trigger of this plugin is "mg-*".
 
-In some editors just the tab key don't trigger the snippet, so you have to press control+space to make the things happen:
+In some editors just the tab key don't trigger the snippet, so you have to check few things to make magic happens like on gif below.
+
+1. Check if you don't have set key binding for user (if so you have to remove it):<br />
+    ```{ "keys": ["tab"], "command": "insert_best_completion", "args": {"default": "\t", "exact": true} },```
+1. If it still doesn't work add to your user settings below line: <br />
+    ```"tab_completion": false,```
+1. Some people have assigned CTRL+Space as the snippet trigger
+1. Check if another package is not coliding with snippet trigger (i.e. Emmet can cause some issues with Sublime Text 3 Snippet usage)
 
 ![MagentoSnippets: example of use](http://www.magefront.com.br/wp-content/uploads/2015/01/MagentoSnippets-sample.gif)
 
@@ -18,7 +25,7 @@ If you have something to improve these snippets, please create a [issue](https:/
 
 **For how to do your own snippet and contribute for this tool see the [contribution text](https://github.com/MageFront/MagentoSnippets/blob/master/contribute.md)**
 
-## Avaiable Snippets
+## Available Snippets
 
 ### XML
 


### PR DESCRIPTION
https://github.com/MageFront/MagentoSnippets/issues/8

Added possible fixes to problem when **TAB** key is not triggering the snippet steps. 
Fixed typo Avaiable > Available
